### PR TITLE
Introduce some sane ZIP handling to Cuckoo.

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -1078,7 +1078,7 @@ class Database(object):
         """
         task_ids = []
         # extract files from the (potential) ZIP
-        extracted_files = demux_sample(file_path)
+        extracted_files = demux_sample(file_path, options)
         # create tasks for each file in the ZIP
         for file in extracted_files:
             task_id = self.add_path(file_path=file,


### PR DESCRIPTION
The existing Cuckoo ZIP handling destroys any possibility for useful analysis -- the strings will be useless, no static analysis will be done on the PE, and the target file is the ZIP itself, throwing off several signatures that are interested in the properties of the original file.

The new handling will create a new analysis for every "interesting" file in the ZIP, those with the extensions listed in demux_sample() or no extension at all.  It will thus skip a notes.txt or the like present in the ZIP.  It will automatically attempt extraction using a password of "infected" or can also use the same password= option supplied to the analysis.